### PR TITLE
Authentication Origin should not be fixed to http://

### DIFF
--- a/src/Alchemy/Handlers/WebSocket/hybi00/Authentication.cs
+++ b/src/Alchemy/Handlers/WebSocket/hybi00/Authentication.cs
@@ -22,14 +22,20 @@ namespace Alchemy.Handlers.WebSocket.hybi00
                 if (handshake.IsValid())
                 {
                     // Optionally check Origin and Location if they're set.
-                    if (Origin != string.Empty)
+                    if (!String.IsNullOrEmpty(Origin))
                     {
-                        if (handshake.Origin != "http://" + Origin)
+                        var expectedOrigin = Origin;
+                        if (!Origin.Contains("://"))
+                        {
+                            expectedOrigin = "http://" + Origin;
+                        }
+
+                        if (!handshake.Origin.Equals(expectedOrigin, StringComparison.InvariantCultureIgnoreCase))
                         {
                             return false;
                         }
                     }
-                    if (Destination != string.Empty)
+                    if (!String.IsNullOrEmpty(Destination))
                     {
                         if (handshake.Host != Destination + ":" + context.Server.Port)
                         {

--- a/src/Alchemy/Handlers/WebSocket/rfc6455/Authentication.cs
+++ b/src/Alchemy/Handlers/WebSocket/rfc6455/Authentication.cs
@@ -21,7 +21,13 @@ namespace Alchemy.Handlers.WebSocket.rfc6455
                     // Optionally check Origin and Location if they're set.
                     if (!String.IsNullOrEmpty(Origin))
                     {
-                        if (handshake.Origin != "http://" + Origin)
+                        var expectedOrigin = Origin;
+                        if (!Origin.Contains("://"))
+                        {
+                            expectedOrigin = "http://" + Origin;
+                        }
+
+                        if (!handshake.Origin.Equals(expectedOrigin, StringComparison.InvariantCultureIgnoreCase))
                         {
                             return false;
                         }


### PR DESCRIPTION
I was writing a chrome extension that is using web sockets to communicate with an application running on the localhost.
A chrome extension will try authenticate itself as `Origin: chrome-extension://mnkmaflojmabglhiddgglabbfmogokfd`. This does not work as Alchemy-Websockets currently is able to authenticate origins from http:// only (https:// is not possible either). 
My commit fixes this issue.
