### PR TITLE
Support for server behaviors

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="../test/Integration/Alchemy/packages.config" />
+  <repository path="../test/Unit/Alchemy/packages.config" />
   <repository path="..\test\Integration\Alchemy\packages.config" />
   <repository path="..\test\Unit\Alchemy\packages.config" />
 </repositories>

--- a/src/Alchemy/Alchemy.csproj
+++ b/src/Alchemy/Alchemy.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Classes\Header.cs" />
     <Compile Include="Classes\Response.cs" />
     <Compile Include="Classes\UserContext.cs" />
+    <Compile Include="Classes\ServerBehaviour.cs" />
     <Compile Include="Handlers\Handler.cs" />
     <Compile Include="Handlers\WebSocket\hybi00\Handler.cs" />
     <Compile Include="Handlers\WebSocket\hybi00\Handshakes.cs" />

--- a/src/Alchemy/Alchemy.csproj
+++ b/src/Alchemy/Alchemy.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Handlers\WebSocket\rfc6455\Handshakes.cs" />
     <Compile Include="Handlers\WebSocket\rfc6455\Handler.cs" />
     <Compile Include="Handlers\WebSocket\WebSocketHandler.cs" />
-    <Compile Include="TcpServer.cs" />
+    <Compile Include="TCPServer.cs" />
     <Compile Include="WebSocketClient.cs" />
     <Compile Include="WebSocketServer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Alchemy/Classes/ServerBehaviour.cs
+++ b/src/Alchemy/Classes/ServerBehaviour.cs
@@ -1,0 +1,36 @@
+namespace Alchemy.Classes
+{
+    /// <summary>
+    /// The server behaviour base class.
+    /// </summary>
+    public abstract class ServerBehaviour
+    {
+        /// <summary>
+        /// The event triggered when the user is connected.
+        /// </summary>
+        /// <param name="context">The current user context.</param>
+        public virtual void OnConnected(UserContext context)
+        { }
+
+        /// <summary>
+        /// The event triggered when the server receive data.
+        /// </summary>
+        /// <param name="context">The current user context.</param>
+        public virtual void OnReceive(UserContext context)
+        { }
+
+        /// <summary>
+        /// The event triggered when the server send data.
+        /// </summary>
+        /// <param name="context">The current user context.</param>
+        public virtual void OnSend(UserContext context)
+        { }
+
+        /// <summary>
+        /// The event triggered when the user is disconnected.
+        /// </summary>
+        /// <param name="context">The current user context.</param>
+        public virtual void OnDisconnect(UserContext context)
+        { }
+    }
+}

--- a/src/Alchemy/WebSocketClient.cs
+++ b/src/Alchemy/WebSocketClient.cs
@@ -98,8 +98,11 @@ namespace Alchemy
         }
         public WebSocketClient(string path)
         {
-            var r = new Regex("^(wss?)://(.*)\\:([0-9]*)/(.*)$");
+            var r = new Regex("^(\\w+)://(.*)\\:([0-9]*)/(.*)$");
             var matches = r.Match(path);
+
+            if (matches.Groups[1].Value != "ws" || matches.Groups[1].Value != "wss")
+                SubProtocols = new string[] {matches.Groups[1].Value};
 
             _host = matches.Groups[2].Value;
             _port = Int32.Parse(matches.Groups[3].Value);

--- a/src/Alchemy/WebSocketClient.cs
+++ b/src/Alchemy/WebSocketClient.cs
@@ -60,7 +60,8 @@ namespace Alchemy
             NewClients = new Queue<Context>();
             ContextMapping = new Dictionary<Context, WebSocketClient>();
 
-            for(int i = 0; i < ClientThreads.Length; i++){
+            for (int i = 0; i < ClientThreads.Length; i++)
+            {
                 ClientThreads[i] = new Thread(HandleClientThread);
                 ClientThreads[i].Start();
             }
@@ -108,7 +109,7 @@ namespace Alchemy
         public void Connect()
         {
             if (_client != null) return;
-            
+
             try
             {
                 ReadyState = ReadyStates.CONNECTING;
@@ -142,7 +143,7 @@ namespace Alchemy
             {
                 _client.EndConnect(result);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Disconnect();
                 connectError = true;
@@ -192,7 +193,7 @@ namespace Alchemy
                 {
                     ReceiveEventArgs_Completed(_context.Connection.Client, _context.ReceiveEventArgs);
                 }
- 
+
 
                 if (!IsAuthenticated)
                 {
@@ -236,7 +237,7 @@ namespace Alchemy
 
         private void Authenticate()
         {
-            _handshake = new ClientHandshake { Version = "8", Origin = Origin, Host = _host, Key = GenerateKey(), ResourcePath = _path, SubProtocols = SubProtocols};
+            _handshake = new ClientHandshake { Version = "8", Origin = Origin, Host = _host, Key = GenerateKey(), ResourcePath = _path, SubProtocols = SubProtocols };
 
             _client.Client.Send(Encoding.UTF8.GetBytes(_handshake.ToString()));
         }
@@ -264,7 +265,7 @@ namespace Alchemy
                     }
 
                 }
-                if(String.IsNullOrEmpty(CurrentProtocol))
+                if (String.IsNullOrEmpty(CurrentProtocol))
                 {
                     return false;
                 }
@@ -305,7 +306,7 @@ namespace Alchemy
 
         private void DoReceive(IAsyncResult result)
         {
-            var context = (Context) result.AsyncState;
+            var context = (Context)result.AsyncState;
             context.Reset();
 
             try
@@ -335,7 +336,7 @@ namespace Alchemy
 
             for (var index = 0; index < bytes.Length; index++)
             {
-                bytes[index] = (byte) random.Next(0, 255);
+                bytes[index] = (byte)random.Next(0, 255);
             }
 
             return Convert.ToBase64String(bytes);
@@ -369,12 +370,12 @@ namespace Alchemy
         {
             _context.UserContext.Send(data);
         }
-        
+
         public void Dispose()
         {
             cancellation.Cancel();
             Handler.Instance.Dispose();
         }
-        
+
     }
 }

--- a/src/Alchemy/WebSocketServer.cs
+++ b/src/Alchemy/WebSocketServer.cs
@@ -37,7 +37,8 @@ namespace Alchemy
             CleanupThread.Name = "WebSocketServer Cleanup Thread";
             CleanupThread.Start();
 
-            for(int i = 0; i < ClientThreads.Length; i++){
+            for (int i = 0; i < ClientThreads.Length; i++)
+            {
                 ClientThreads[i] = new Thread(HandleClientThread);
                 ClientThreads[i].Name = "WebSocketServer Client Thread #" + (i + 1);
                 ClientThreads[i].Start();
@@ -67,7 +68,8 @@ namespace Alchemy
                     client.SetupContext(context);
                 }
 
-                lock(CurrentConnections){
+                lock (CurrentConnections)
+                {
                     CurrentConnections.Add(context);
                 }
             }
@@ -89,7 +91,7 @@ namespace Alchemy
                 foreach (var connection in currentConnections)
                 {
                     if (cancellation.IsCancellationRequested) break;
-                    
+
                     if (!connection.Connected)
                     {
                         lock (CurrentConnections)
@@ -153,7 +155,7 @@ namespace Alchemy
         /// <summary>
         /// Initializes a new instance of the <see cref="WebSocketServer"/> class.
         /// </summary>
-        public WebSocketServer(int listenPort = 0, IPAddress listenAddress = null) : base(listenPort, listenAddress) {}
+        public WebSocketServer(int listenPort = 0, IPAddress listenAddress = null) : base(listenPort, listenAddress) { }
 
         /// <summary>
         /// Gets or sets the origin host.
@@ -252,7 +254,7 @@ namespace Alchemy
         /// <param name="result">The Async result.</param>
         private void DoReceive(IAsyncResult result)
         {
-            var context = (Context) result.AsyncState;
+            var context = (Context)result.AsyncState;
             context.Reset();
             try
             {
@@ -274,6 +276,7 @@ namespace Alchemy
                 context.ReceiveReady.Release();
             }
         }
+
         private void SetupContext(Context _context)
         {
             _context.ReceiveEventArgs.UserToken = _context;
@@ -282,6 +285,7 @@ namespace Alchemy
 
             StartReceive(_context);
         }
+        
         private void StartReceive(Context _context)
         {
             try
@@ -295,7 +299,7 @@ namespace Alchemy
                             ReceiveEventArgs_Completed(_context.Connection.Client, _context.ReceiveEventArgs);
                         }
                     }
-                    catch (SocketException ex)
+                    catch (SocketException)
                     {
                         //logger.Error("SocketException in ReceieveAsync", ex);
                         _context.Disconnect();
@@ -309,15 +313,18 @@ namespace Alchemy
             }
             catch (OperationCanceledException) { }
         }
+
         void ReceiveEventArgs_Completed(object sender, SocketAsyncEventArgs e)
         {
             var context = (Context)e.UserToken;
             context.Reset();
             if (e.SocketError != SocketError.Success)
             {
-            //logger.Error("Socket Error: " + e.SocketError.ToString());
+                //logger.Error("Socket Error: " + e.SocketError.ToString());
                 context.ReceivedByteCount = 0;
-            } else {
+            }
+            else
+            {
                 context.ReceivedByteCount = e.BytesTransferred;
             }
 
@@ -326,17 +333,19 @@ namespace Alchemy
                 context.Handler.HandleRequest(context);
                 context.ReceiveReady.Release();
                 StartReceive(context);
-            } else {
+            }
+            else
+            {
                 context.Disconnect();
                 context.ReceiveReady.Release();
             }
         }
-        
-        public void Dispose()
+
+        public new void Dispose()
         {
             cancellation.Cancel();
             base.Dispose();
             Handler.Instance.Dispose();
-        }        
+        }
     }
 }

--- a/src/Alchemy/WebSocketServer.cs
+++ b/src/Alchemy/WebSocketServer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Net.Sockets;
 using System.Threading;
 using Alchemy.Classes;
@@ -120,14 +122,20 @@ namespace Alchemy
 
         /// <summary>
         /// These are the default OnEvent delegates for the server. By default, all new UserContexts will use these events.
-        /// It is up to you whether you want to replace them at runtime or even manually set the events differently per connection in OnReceive.
         /// </summary>
         public OnEventDelegate OnConnect = x => { };
-
         public OnEventDelegate OnConnected = x => { };
         public OnEventDelegate OnDisconnect = x => { };
         public OnEventDelegate OnReceive = x => { };
         public OnEventDelegate OnSend = x => { };
+
+        /// <summary>
+        /// These are events passed to the context to manage server behaviours.
+        /// </summary>
+        private OnEventDelegate _onConnected = x => { };
+        private OnEventDelegate _onDisconnect = x => { };
+        private OnEventDelegate _onReceive = x => { };
+        private OnEventDelegate _onSend = x => { };
 
         /// <summary>
         /// Enables or disables the Flash Access Policy Server(APServer).
@@ -152,10 +160,65 @@ namespace Alchemy
         private string _destination = String.Empty;
         private string _origin = String.Empty;
 
+        private Dictionary<string, ServerBehaviour> _behaviours = new Dictionary<string, ServerBehaviour>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WebSocketServer"/> class.
         /// </summary>
-        public WebSocketServer(int listenPort = 0, IPAddress listenAddress = null) : base(listenPort, listenAddress) { }
+        public WebSocketServer(int listenPort = 0, IPAddress listenAddress = null) : base(listenPort, listenAddress)
+        {
+            _onConnected = (context) =>
+            {
+                OnConnected(context);
+                var keys = _behaviours.Keys.Where(k => Regex.IsMatch(context.RequestPath, $"^{k}$"));
+                if (keys.Count() > 0)
+                {
+                    foreach (var k in keys)
+                    {
+                        _behaviours[k].OnConnected(context);
+                    }
+                }
+            };
+
+            _onReceive = (context) =>
+            {
+                OnReceive(context);
+                var keys = _behaviours.Keys.Where(k => Regex.IsMatch(context.RequestPath, $"^{k}$"));
+                if (keys.Count() > 0)
+                {
+                    foreach (var k in keys)
+                    {
+                        _behaviours[k].OnReceive(context);
+                    }
+                }
+            };
+
+            _onSend = (context) =>
+            {
+                OnSend(context);
+                var keys = _behaviours.Keys.Where(k => Regex.IsMatch(context.RequestPath, $"^{k}$"));
+                if (keys.Count() > 0)
+                {
+                    foreach (var k in keys)
+                    {
+                        _behaviours[k].OnSend(context);
+                    }
+                }
+            };
+
+            _onDisconnect = (context) =>
+            {
+                OnDisconnect(context);
+                var keys = _behaviours.Keys.Where(k => Regex.IsMatch(context.RequestPath, $"^{k}$"));
+                if (keys.Count() > 0)
+                {
+                    foreach (var k in keys)
+                    {
+                        _behaviours[k].OnDisconnect(context);
+                    }
+                }
+            };
+        }
 
         /// <summary>
         /// Gets or sets the origin host.
@@ -186,6 +249,21 @@ namespace Alchemy
             {
                 _destination = value;
                 Authentication.Destination = value;
+            }
+        }
+
+        /// <summary>
+        /// Add a new server behaviour.
+        /// </summary>
+        /// <param name="path">The request path to apply the behaviour. Can be a <see cref="Regex"/>.</param>
+        /// <param name="behaviour">The <see cref="ServerBehaviour"/> to use when the user connect using the <paramref name="path"/></param>
+        public void AddServerBehaviour(string path, ServerBehaviour behaviour)
+        {
+            string key = path.TrimEnd('/');
+
+            if (!_behaviours.ContainsKey(key))
+            {
+                _behaviours.Add(path, behaviour);
             }
         }
 
@@ -230,10 +308,10 @@ namespace Alchemy
 
             context.UserContext.ClientAddress = context.Connection.Client.RemoteEndPoint;
             context.UserContext.SetOnConnect(OnConnect);
-            context.UserContext.SetOnConnected(OnConnected);
-            context.UserContext.SetOnDisconnect(OnDisconnect);
-            context.UserContext.SetOnSend(OnSend);
-            context.UserContext.SetOnReceive(OnReceive);
+            context.UserContext.SetOnConnected(_onConnected);
+            context.UserContext.SetOnDisconnect(_onDisconnect);
+            context.UserContext.SetOnSend(_onSend);
+            context.UserContext.SetOnReceive(_onReceive);
             context.BufferSize = BufferSize;
             context.UserContext.OnConnect();
 
@@ -344,7 +422,7 @@ namespace Alchemy
             }
         }
 
-        public void Dispose()
+        public new void Dispose()
         {
             cancellation.Cancel();
             base.Dispose();

--- a/test/Integration/Alchemy/Alchemy.csproj
+++ b/test/Integration/Alchemy/Alchemy.csproj
@@ -54,12 +54,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Alchemy\Alchemy.csproj">
-      <Project>{45486CDE-86A3-4769-952F-E0821BF79493}</Project>
-      <Name>Alchemy %28src\Alchemy%29</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -70,4 +64,10 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <ProjectReference Include="Alchemy.csproj">
+      <Project>{D7B6AB15-5986-4FDC-ADA8-9EF14DF8F26D}</Project>
+      <Name>Alchemy</Name>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/test/Unit/Alchemy/Alchemy.csproj
+++ b/test/Unit/Alchemy/Alchemy.csproj
@@ -40,6 +40,8 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <WarningLevel>4</WarningLevel>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -50,17 +52,12 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Handlers\WebSocket\hybi00\DataFrame.cs" />
     <Compile Include="Handlers\WebSocket\hybi10\DataFrame.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Alchemy\Alchemy.csproj">
-      <Project>{45486CDE-86A3-4769-952F-E0821BF79493}</Project>
-      <Name>Alchemy %28src\Alchemy%29</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="nunit.framework">
@@ -84,4 +81,10 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\Integration\Alchemy\Alchemy.csproj">
+      <Project>{D7B6AB15-5986-4FDC-ADA8-9EF14DF8F26D}</Project>
+      <Name>Alchemy</Name>
+    </ProjectReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi !
I've made a modification to Alchemy, allowing users to define the behavior of the server according to the route used by the client, so the server can handle specific events for the given route. For example, a client **A** connect to the server with the route **/chat** and the **OnConnected** event echo the message **Welcome to the chat service!**, but when the client **B** connect to the server with the route **/admin** the **OnConnected** event echo the message **Admin access granted**.